### PR TITLE
Python 3.11 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,9 @@ jobs:
     parameters: {tox: 'py310', python: '3.10', os: 'linux'}
   #
   - template: azure-template-tox-job.yml
+    parameters: {tox: 'py311', python: '3.11', os: 'linux'}
+  #
+  - template: azure-template-tox-job.yml
     parameters: {tox: 'py310', python: '3.10', os: 'macos'}
   #
   - template: azure-template-publish-job.yml

--- a/azure-template-tox-job.yml
+++ b/azure-template-tox-job.yml
@@ -141,6 +141,11 @@ jobs:
           export CONFIG_SUPPORT_TOKEN_ENV=$(VAR_CONFIG_SUPPORT_TOKEN_ENV)
           ${{ format('python -m tox -e {0}', parameters.tox) }}
         displayName: 'Running tox task'
+    - ${{ if and(not(startsWith(parameters.tox, 'py')), startsWith(parameters.python, '3.11')) }}:
+      - script: |
+          export CONFIG_SUPPORT_TOKEN_ENV=$(VAR_CONFIG_SUPPORT_TOKEN_ENV)
+          ${{ format('python -m tox -e {0}-py311', parameters.tox) }}
+        displayName: 'Running tox task'
     - ${{ if and(not(startsWith(parameters.tox, 'py')), startsWith(parameters.python, '3.10')) }}:
       - script: |
           export CONFIG_SUPPORT_TOKEN_ENV=$(VAR_CONFIG_SUPPORT_TOKEN_ENV)

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ if not version:
 
 setup(
     name=thisPackage,
+    python_requires=">=3.6",
     version=version,
     description="Alignment Library and Tools",
     long_description="See:  README.md",
@@ -141,11 +142,13 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     # entry_points={
     #    'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,28 @@ commands =
     {envpython} -m unittest discover -v --start-directory {[local_settings]test_path_4} --pattern "{[local_settings]test_pattern}"
     echo "Completed {envname}"
 
+[testenv:py311]
+description = 'Run unit tests (unittest runner) using {envpython}'
+whitelist_externals = echo
+platform=
+       macos: darwin
+       linux: linux
+basepython = py311: python3.11
+skip_install = false
+recreate = true
+alwayscopy=true
+usedevelop=true
+deps = 
+       -r requirements.txt
+commands =
+    echo "Starting {envname}"
+    {envpython} -V
+    {envpython} -m unittest discover -v --start-directory {[local_settings]test_path_1} --pattern "{[local_settings]test_pattern}"
+    {envpython} -m unittest discover -v --start-directory {[local_settings]test_path_2} --pattern "{[local_settings]test_pattern}"
+    {envpython} -m unittest discover -v --start-directory {[local_settings]test_path_3} --pattern "{[local_settings]test_pattern}"
+    {envpython} -m unittest discover -v --start-directory {[local_settings]test_path_4} --pattern "{[local_settings]test_pattern}"
+    echo "Completed {envname}"
+
 [testenv:py310]
 description = 'Run unit tests (unittest runner) using {envpython}'
 whitelist_externals = echo


### PR DESCRIPTION
Drop support for python < 3.6 by using newer pybind11.

Mark this version as 3.6 and up.