### PR TITLE
Remove future and six from build requirements -- not needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-future
-six
+#future
+#six

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ setup(
     #    ]
     # },
     #
-    install_requires=["future", "six"],
+    install_requires=[],
     # packages=find_packages(exclude=["wwpdb.utils.tests-align", "tests.*"]),
     # We are explicit here - as we removed the intermediate __init__.py
     packages=["wwpdb", "wwpdb.utils", "wwpdb.utils.align"],


### PR DESCRIPTION
Future and six are not needed to build this package.  Remove as requirements.